### PR TITLE
feat,UI: 닉네임 설정 페이지및 공용 활성화 비활성화 버튼 예시 생성

### DIFF
--- a/src/app/_components/common/CommonButton.module.scss
+++ b/src/app/_components/common/CommonButton.module.scss
@@ -1,0 +1,17 @@
+.button {
+  @include flexbox;
+  @include text-style(16, $white, light);
+
+  padding: 1.5rem 0;
+  width: 100%;
+  background-color: $gray;
+  border: none;
+  border-radius: 0.6rem;
+  cursor: not-allowed;
+  transition: $base-transition;
+
+  &.enabled {
+    background-color: $primary; /* 버튼 활성화 색상 */
+    cursor: pointer;
+  }
+}

--- a/src/app/_components/common/CommonButton.tsx
+++ b/src/app/_components/common/CommonButton.tsx
@@ -1,0 +1,28 @@
+import React from 'react';
+import classNames from 'classnames/bind';
+import styles from './CommonButton.module.scss';
+
+const cx = classNames.bind(styles);
+
+interface CommonButtonProps {
+  isEnabled: boolean;
+  onClick: () => void;
+  text: string;
+}
+
+export default function CommonButton({
+  isEnabled,
+  onClick,
+  text,
+}: CommonButtonProps) {
+  return (
+    <button
+      type="button"
+      disabled={!isEnabled}
+      onClick={onClick}
+      className={cx('button', { enabled: isEnabled })}
+    >
+      {text}
+    </button>
+  );
+}

--- a/src/app/nicknamesetting/NicknamePage.module.scss
+++ b/src/app/nicknamesetting/NicknamePage.module.scss
@@ -1,0 +1,50 @@
+.container {
+  @include column-flexbox(center, start, 4rem);
+
+  width: 100%;
+  padding: 10.5rem 2.4rem 0;
+  transition: $base-transition;
+}
+
+.introduction {
+  @include text-style(24);
+
+  margin-bottom: 1.2rem;
+
+  .bold {
+    @include text-style(24, $black, bold);
+  }
+}
+.input-group {
+  @include column-flexbox(center, start, 0.6rem);
+
+  width: 100%;
+
+  .title {
+    @include text-style(18, $black, bolder);
+  }
+
+  .description {
+    @include text-style(14, $black, light);
+
+    margin-bottom: 0.4rem;
+  }
+
+  .input {
+    @include text-style(14);
+
+    transition: $base-transition;
+    width: 100%;
+    border-radius: 0.6rem;
+    border: 0.05rem solid $gray;
+    padding: 1.4rem 1.5rem;
+    &::placeholder {
+      @include text-style(14, $gray, light);
+    }
+
+    &:focus {
+      border-color: $primary;
+      outline: none;
+    }
+  }
+}

--- a/src/app/nicknamesetting/page.tsx
+++ b/src/app/nicknamesetting/page.tsx
@@ -1,0 +1,56 @@
+'use client';
+
+import React, { useState } from 'react';
+import classNames from 'classnames/bind';
+import CommonButton from '../_components/common/CommonButton'; // 공용 버튼 컴포넌트 경로
+import styles from './NicknamePage.module.scss';
+
+const cx = classNames.bind(styles);
+
+export default function NicknamePage() {
+  const [nickname, setNickname] = useState('');
+  const [isButtonEnabled, setIsButtonEnabled] = useState(false);
+
+  const handleInputChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const input = e.target.value;
+
+    const isValid =
+      input.trim().length > 0 &&
+      input.trim().length <= 10 &&
+      !input.includes(' ');
+    setNickname(input);
+    setIsButtonEnabled(isValid);
+  };
+
+  const handleNextStep = () => {
+    console.log('다음 단계로 이동합니다.');
+  };
+
+  return (
+    <div className={cx('container')}>
+      <div className={cx('introduction')}>
+        <span className={cx('bold')}>트립 테리어의 </span> <br />
+        기본 정보를 입력해주세요!
+      </div>
+      <label htmlFor="nickname" className={cx('input-group')}>
+        <p className={cx('title')}>닉네임</p>
+        <p className={cx('description')}>
+          닉네임은 공백 없는 10글자 이하만 가능해요.
+        </p>
+        <input
+          type="text"
+          id="nickname"
+          value={nickname}
+          onChange={handleInputChange}
+          placeholder="닉네임을 입력하세요"
+          className={cx('input')}
+        />
+      </label>
+      <CommonButton
+        isEnabled={isButtonEnabled}
+        onClick={handleNextStep}
+        text="다음 단계로"
+      />
+    </div>
+  );
+}


### PR DESCRIPTION
## 📋 작업 내용
> *이미지 또는 동영상 추가도 가능
- 닉네임 설정 페이지및 공용 활성화 비활성화 버튼 예시 생성

<br /> 
![screencapture-localhost-3000-nicknamesetting-2024-09-12-15_54_08](https://github.com/user-attachments/assets/1b515465-1700-4b46-9b11-17eb7c32cd49)
![screencapture-localhost-3000-nicknamesetting-2024-09-12-15_57_22](https://github.com/user-attachments/assets/37d51975-b94b-498b-959a-2a41c75ec2f3)


## 🔢 이슈 번호

> 예) close #77

close #6 

<br /> 

## 🔢 리뷰 요구사항(선택)
> 코드리뷰시 특별히 봐주었으면 하는 부분 작성
- 직전에 올린 pr에 올린 폰트와 믹스인이 아직 머지되지 않아서 사진으로는 미완성으로 보여도 전 pr이 머지되면 괜찮게 보일 예정
